### PR TITLE
基礎編「ドキュメントを編集しよう」のprovideCodeLensesの実装を簡潔にする提案

### DIFF
--- a/docs/beginner/04_edit.md
+++ b/docs/beginner/04_edit.md
@@ -144,9 +144,7 @@ export class CodelensProvider implements vscode.CodeLensProvider {
     while ((matches = regex.exec(text)) !== null) {
       // 見出しが見つかった行を抽出し、
       // その範囲をレンジとして切り出す
-      const line = document.lineAt(document.positionAt(matches.index).line);
-      const indexOf = line.text.indexOf(matches[0]);
-      const position = new vscode.Position(line.lineNumber, indexOf);
+      const position = document.positionAt(matches.index);
       const range = document.getWordRangeAtPosition(
         position,
         new RegExp(titleRegex)
@@ -251,9 +249,7 @@ export class CodelensProvider implements vscode.CodeLensProvider {
     while ((matches = regex.exec(text)) !== null) {
       // 見出しが見つかった行を抽出し、
       // その範囲をレンジとして切り出す
-      const line = document.lineAt(document.positionAt(matches.index).line);
-      const indexOf = line.text.indexOf(matches[0]);
-      const position = new vscode.Position(line.lineNumber, indexOf);
+      const position = document.positionAt(matches.index);
       const range = document.getWordRangeAtPosition(
         position,
         new RegExp(titleRegex)


### PR DESCRIPTION
`document.positionAt(matches.index)`が`vscode.Position`を返しているので、
（それを使って新たに`vscode.Position`を作る代わりに）そのまま使って`document.getWordRangeAtPosition`すればよいと考えます。

この提案に至るまでの思考は、以下のブログにアウトプットしています。
https://nikkie-ftnext.hatenablog.com/entry/vscode-extension-provide-codelens-with-vscode-api 
「rangeの取得をよりシンプルに置き換える提案」を参照ください

変更した実装で動くことを確認しています（VS Code Conference JP 2022-2023の拡張開発のトークでデモしたのは簡潔にしたバージョンでした）
ref: https://github.com/ftnext/2023-slides/commit/6258a711b8a7a3b2a3fd9ebcc644feeb7161e109